### PR TITLE
Remove Microsoft.AspNetCore.Components.Web dependency

### DIFF
--- a/FluentValidation.Blazor/Accelist.FluentValidation.Blazor.csproj
+++ b/FluentValidation.Blazor/Accelist.FluentValidation.Blazor.csproj
@@ -40,7 +40,7 @@ Version 4.0.0 BREAKING CHANGES:
   <ItemGroup>
     <PackageReference Include="FluentValidation" Version="9.3.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components" Version="5.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="5.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Forms" Version="5.0.0" />
   </ItemGroup>
 
 </Project>

--- a/FluentValidation.Blazor/_Imports.razor
+++ b/FluentValidation.Blazor/_Imports.razor
@@ -1,1 +1,0 @@
-﻿@using Microsoft.AspNetCore.Components.Web


### PR DESCRIPTION
Replace `Microsoft.AspNetCore.Components.Web` dependency with `Microsoft.AspNetCore.Components.Forms`.
That would allow to avoid unnecessary dependencies when using this library with non-Web Blazor implementations (e.g. https://github.com/xamarin/MobileBlazorBindings). 

I've also removed `_Imports.razor` file, is that needed for some reason?