### PR TITLE
Clearable fluent validator

### DIFF
--- a/Demo.Forms/Models/NestedForm.cs
+++ b/Demo.Forms/Models/NestedForm.cs
@@ -13,6 +13,14 @@ namespace Demo.Forms.Models
         public List<ChildForm> SubArray { set; get; }
 
         public MustNotValidate NotAForm { set; get; }
+
+        public void Clear()
+        {
+            Email = String.Empty;
+            Child = new ChildForm();
+            SubArray = new List<ChildForm> { new ChildForm { }, new ChildForm { } };
+            NotAForm = new MustNotValidate();
+        }
     }
 
     public class ChildForm

--- a/Demo/Pages/Index.razor
+++ b/Demo/Pages/Index.razor
@@ -19,7 +19,7 @@
 <h1>Form 2: Dependency Injection Validation</h1>
 
 <EditForm Model="Form2">
-    <FluentValidator></FluentValidator>
+    <FluentValidator @ref="Form2FluentValidator"></FluentValidator>
     <div class="form-group">
         <label for="email">Email</label>
         <InputText id="email" class="form-control" @bind-Value="Form2.Email"></InputText>
@@ -54,6 +54,9 @@
         </button>
     </div>
 </EditForm>
+<button class="btn btn-primary" @onclick="ClearForm2">
+    Clear Form
+</button>
 
 <h1>Submitting / Editing This Form Will Crash The App</h1>
 
@@ -85,4 +88,13 @@
     };
 
     CrashForm CrashForm = new CrashForm();
+
+    FluentValidator Form2FluentValidator;
+
+    void ClearForm2()
+    {
+        Form2.Clear();
+        Form2FluentValidator.ClearMessages();
+    }
+
 }

--- a/FluentValidation.Blazor/Accelist.FluentValidation.Blazor.csproj
+++ b/FluentValidation.Blazor/Accelist.FluentValidation.Blazor.csproj
@@ -32,6 +32,7 @@ Version 5.0.0 BREAKING CHANGES:
 - Package sub-dependency Microsoft.AspNetCore.Components.Web is changed to Microsoft.AspNetCore.Components.Forms to allow using the library in Xamarin Blazor project!
 - Package is now compatible with both .NET 5.0 and .NET Core 3.1
 		</PackageReleaseNotes>
+		<PackageId>ClearableFluentValidation.Blazor</PackageId>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/FluentValidation.Blazor/FluentValidator.cs
+++ b/FluentValidation.Blazor/FluentValidator.cs
@@ -72,6 +72,9 @@ namespace Microsoft.AspNetCore.Components.Forms
             this.AddValidation();
         }
 
+        /// <summary>
+        /// Clear all validation messages.
+        /// </summary>
         public void ClearMessages()
         {
             MessageStore.Clear();


### PR DESCRIPTION
I modified the FluentValidator quite a bit in order to be able to clear all vadliation messages.
In order to do that, I set the ValidationMessageStore as an attribute of the FluentValidator class. It seems to work fine and allows to clear validation messages. 
This is useful for example in case of a form inside a modal, if you want the form to be cleared when the modal is closed. 
I added a button the Demo to clear entirely the 2nd form.