### PR TITLE
Fix version conflicts caused by PR#84

### DIFF
--- a/FluentValidation.Blazor/Accelist.FluentValidation.Blazor.csproj
+++ b/FluentValidation.Blazor/Accelist.FluentValidation.Blazor.csproj
@@ -39,8 +39,8 @@ Version 4.0.0 BREAKING CHANGES:
 
   <ItemGroup>
     <PackageReference Include="FluentValidation" Version="9.3.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components" Version="5.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="5.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components" Version="5.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="5.0.7" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
I encountered a similar dependency hell issue when bump Microsoft.AspNetCore.Components.Web from 5.0.0 to 5.0.7. [(PR#84)](https://github.com/ryanelian/FluentValidation.Blazor/pull/84).
Hope this fix can help you.

Best regards,
sucrose